### PR TITLE
Fix acks to acks

### DIFF
--- a/src/linkLayer.js
+++ b/src/linkLayer.js
@@ -342,7 +342,7 @@ class LinkLayer extends Duplex {
 
         // if this is an ack, callback immediately
         if (msg.isAck) {
-            clearTimeout(this.timeout);
+            clearTimeout(this.timer);
             process.nextTick(() => {
                 this.callbackWrite = null;
                 callback();

--- a/src/linkLayer.js
+++ b/src/linkLayer.js
@@ -143,7 +143,7 @@ class LinkLayer extends Duplex {
         this.messageParts = 0;
         let length = data.payload.length;
 
-        //Multi Parts           
+        //Multi Parts
         if (length > 9979) {
             let msgPart = 1;
             let parts = length / 9979;
@@ -339,6 +339,16 @@ class LinkLayer extends Duplex {
             if (this.sequenceNumber > 99) {
                 this.sequenceNumber = 1;
             }
+        }
+
+        // if this is an ack, callback immediately
+        if (msg.isAck) {
+            clearTimeout(this.timeout);
+            delete msg.isAck;
+            process.nextTick(() => {
+                this.callbackWrite = null;
+                callback();
+            });
         }
 
         this.midSerializer.write(msg);

--- a/src/linkLayer.js
+++ b/src/linkLayer.js
@@ -134,8 +134,7 @@ class LinkLayer extends Duplex {
     }
 
     _onDataMidSerializer(data) {
-
-        if (data.mid !== NEGATIVE_ACK && data.mid !== POSITIVE_ACK) {
+        if (data.mid !== NEGATIVE_ACK && data.mid !== POSITIVE_ACK && !data.isAck) {
             clearTimeout(this.timer);
             this.timer = setTimeout(() => this._resendMid(), this.timeOut);
         }
@@ -178,7 +177,7 @@ class LinkLayer extends Duplex {
             return;
         }
 
-        if (data.mid !== POSITIVE_ACK && data.mid !== NEGATIVE_ACK) {
+        if (data.mid !== POSITIVE_ACK && data.mid !== NEGATIVE_ACK && !data.isAck) {
             this.message = data;
         }
 
@@ -344,7 +343,6 @@ class LinkLayer extends Duplex {
         // if this is an ack, callback immediately
         if (msg.isAck) {
             clearTimeout(this.timeout);
-            delete msg.isAck;
             process.nextTick(() => {
                 this.callbackWrite = null;
                 callback();

--- a/src/sessionControlClient.js
+++ b/src/sessionControlClient.js
@@ -179,7 +179,7 @@ class SessionControlClient extends EventEmitter {
         this.defaultRevisions = opts.defaultRevisions || {};
 
         //LinkLayer
-        //If true activate Link Layer 
+        //If true activate Link Layer
         //If false not activate Link Layer
         //If undefined autoNegotiation Link Layer
         this.useLinkLayer = opts.linkLayerActivate;
@@ -501,7 +501,7 @@ class SessionControlClient extends EventEmitter {
      * });
      *
      * sessionControlClient.sendMid(1, opts, (err) => {
-     *  
+     *
      *  if (err) {
      *      console.log("an error has occurred", err);
      *      return;
@@ -997,7 +997,7 @@ class SessionControlClient extends EventEmitter {
 
                 let errorCode = data.payload.errorCode;
 
-                //Error 74: Subscribed MID Revision unsupported 
+                //Error 74: Subscribed MID Revision unsupported
                 //Error 76: Requested MID Revision unsupported
                 if (errorCode === 74 || errorCode === 76) {
                     this.changeRevision = true;
@@ -1052,9 +1052,9 @@ class SessionControlClient extends EventEmitter {
             this.ll.finishCycle();
 
             if (!this.useLinkLayer) {
-
                 this.ll.write({
-                    mid: midGroupList[dataGroup].ack
+                    mid: midGroupList[dataGroup].ack,
+                    isAck: true
                 });
 
                 return;


### PR DESCRIPTION
Fixes #10 

* when an ack mid is being written to the LinkLayer by SessionControlClient, mark it as such
* when the link layer is sending a mid, cancel the timeout and just write the mid
* treat ack mids like 108 just like positive/negative acks

(some whitespace was also trimmed)