### PR TITLE
Ability to access raw data from all MIDs sent or received

### DIFF
--- a/src/linkLayer.js
+++ b/src/linkLayer.js
@@ -57,7 +57,9 @@ class LinkLayer extends Duplex {
         }
 
         //Create instances of manipulators
-        this.opParser = new OpenProtocolParser();
+        this.opParser = new OpenProtocolParser({
+            rawData: opts.rawData
+        });
         this.opSerializer = new OpenProtocolSerializer();
         this.midParser = new MIDParser();
         this.midSerializer = new MIDSerializer();
@@ -190,15 +192,10 @@ class LinkLayer extends Duplex {
     }
 
     _onDataStream(data) {
-        if (this.rawData) {
-            this.dataRaw = Buffer.from(data);
-        }
-
         this.opParser.write(data);
     }
 
     _onDataOpParser(data) {
-
         let duplicateMsg = false;
 
         if (this.linkLayerActive) {
@@ -237,10 +234,6 @@ class LinkLayer extends Duplex {
                 if (!duplicateMsg) {
 
                     if (this.disableMidParsing[data.mid] && (data.mid !== POSITIVE_ACK && data.mid !== NEGATIVE_ACK)) {
-
-                        if (this.rawData) {
-                            data._raw = Buffer.from(this.dataRaw);
-                        }
 
                         if (!this.push(data)) {
                             this.stream.pause();
@@ -293,9 +286,6 @@ class LinkLayer extends Duplex {
 
         if (!duplicateMsg) {
             if (this.disableMidParsing[data.mid] && (data.mid !== POSITIVE_ACK && data.mid !== NEGATIVE_ACK)) {
-                if (this.rawData) {
-                    data._raw = Buffer.from(this.dataRaw);
-                }
 
                 if (!this.push(data)) {
                     this.stream.pause();
@@ -315,10 +305,6 @@ class LinkLayer extends Duplex {
         if (data.mid === POSITIVE_ACK || data.mid === NEGATIVE_ACK) {
             this._receiverLinkLayer(data);
             return;
-        }
-
-        if (this.rawData) {
-            data._raw = Buffer.from(this.dataRaw);
         }
 
         if (!this.push(data)) {

--- a/src/openProtocolParser.js
+++ b/src/openProtocolParser.js
@@ -42,6 +42,7 @@ class OpenProtocolParser extends Transform {
 
         super(opts);
 
+        this.rawData = opts.rawData || false;
         this._nBuffer = null;
         debug("new OpenProtocolParser");
     }
@@ -65,9 +66,10 @@ class OpenProtocolParser extends Transform {
 
         while (ptr < chunk.length) {
 
-            let obj = {
-                raw: chunk
-            };
+            let obj = {};
+            if (this.rawData) {
+                obj._raw = chunk;
+            }
 
             let length = chunk.toString(encodingOP, ptr, ptr + 4);
 

--- a/src/openProtocolParser.js
+++ b/src/openProtocolParser.js
@@ -67,9 +67,7 @@ class OpenProtocolParser extends Transform {
         while (ptr < chunk.length) {
 
             let obj = {};
-            if (this.rawData) {
-                obj._raw = chunk;
-            }
+            let startPtr = ptr;
 
             let length = chunk.toString(encodingOP, ptr, ptr + 4);
 
@@ -245,6 +243,10 @@ class OpenProtocolParser extends Transform {
             obj.payload = chunk.slice(ptr, (ptr + length - 20));
 
             ptr += (length - 20) + 1;
+
+            if (this.rawData) {
+                obj._raw = chunk.slice(startPtr, ptr);
+            }
 
             this.push(obj);
         }

--- a/src/openProtocolParser.js
+++ b/src/openProtocolParser.js
@@ -65,17 +65,19 @@ class OpenProtocolParser extends Transform {
 
         while (ptr < chunk.length) {
 
-            let obj = {};
+            let obj = {
+                raw: chunk
+            };
 
             let length = chunk.toString(encodingOP, ptr, ptr + 4);
 
             length = Number(length);
 
             if (isNaN(length) || length < 1 || length > 9999) {
-                
+
                 let e = new Error(`Invalid length [${length}]`);
-                e.errno = constants.ERROR_LINKLAYER.INVALID_LENGTH;                             
-               
+                e.errno = constants.ERROR_LINKLAYER.INVALID_LENGTH;
+
                 cb(e);
 
                 debug("OpenProtocolParser _transform err-length:", ptr, chunk);
@@ -90,7 +92,7 @@ class OpenProtocolParser extends Transform {
 
             if (chunk[ptr + length] !== 0) {
                 let e = new Error(`Invalid message [${chunk.toString()}]`);
-                e.errno = constants.ERROR_LINKLAYER.INVALID_LENGTH;                            
+                e.errno = constants.ERROR_LINKLAYER.INVALID_LENGTH;
                 cb(e);
                 debug("OpenProtocolParser _transform err-message:", ptr, chunk);
                 return;
@@ -119,7 +121,7 @@ class OpenProtocolParser extends Transform {
 
             if (isNaN(obj.revision) || obj.revision < 0 || obj.revision > 999) {
                 let e = new Error(`Invalid revision [${revision}]`);
-                e.errno = constants.ERROR_LINKLAYER.INVALID_REVISION;   
+                e.errno = constants.ERROR_LINKLAYER.INVALID_REVISION;
                 e.obj = obj;
                 cb(e);
                 debug("OpenProtocolParser _transform err-revision:", ptr, chunk);

--- a/src/sessionControlClient.js
+++ b/src/sessionControlClient.js
@@ -297,6 +297,8 @@ class SessionControlClient extends EventEmitter {
 
         let receivedReply = (data) => {
 
+            this.emit("data", data);
+
             if (data.mid === 4) {
 
                 if (data.payload.midNumber !== 1) {


### PR DESCRIPTION
This adds the ability for OpParser to be used without the LinkLayer. My team found this useful for debugging purposes, and being able to pipe messages that are already serialized through it. The main goal for this was to get raw data logged for **every** MID exchanged between node and the tool.

* objects written in the OpParser's `_transform` are given a `_raw` property
* this replaces the need for LinkLayer to set the _raw property
* add a "data" emit to the SessionControlClient while the initial handshake takes place

Example usage:
```js
const conn = new openProtocol.SessionControlClient({
    stream: socket,
    rawData: true
});

// log messages sent from controller (tool)
conn.on('data', data => {
    console.log('CONTROLLER', data); // CONTROLLER { ... _raw: ... }
});

// log messages sent from integrator (node)
const opWriteInspector = new openProtocol.OpenProtocolParser({
    rawData: true
});
const midWriteInspector = new openProtocol.MIDParser();
conn.ll.opSerializer.pipe(opWriteInspector);
opWriteInspector.pipe(midWriteInspector);
midWriteInspector.on('data', data => {
    console.log('INTEGRATOR', data); // INTEGRATOR { ... _raw: ... }
});
```

(some white spaces were trimmer too)