### PR TITLE
Typed constants

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,9 +11,9 @@ const MIDSerializer = require("./src/MIDSerializer.js");
 const helpers = require("./src/helpers.js");
 const SessionControlClient = require("./src/sessionControlClient.js");
 
-const midGroups = require("./src/midGroups.json");
-const midCommand = require("./src/midCommand.json");
-const midrequest = require("./src/midRequest.json");
+const midGroups = require("./src/midGroups");
+const midCommand = require("./src/midCommand");
+const midrequest = require("./src/midRequest");
 
 const net = require("net");
 

--- a/package.json
+++ b/package.json
@@ -7,9 +7,21 @@
     "doc": "doc"
   },
   "scripts": {
+    "build": "tsc",
     "test": "nyc --reporter=html --reporter=text --reporter=text-summary mocha --timeout=3000 test/**/**.spec.js",
-    "doc": "jsdoc -d docs/jsdoc/ -r -R README.md src/"
+    "doc": "jsdoc -d docs/jsdoc/ -r -R README.md src/",
+    "prepack": "tsc"
   },
+  "typesVersions": {
+    "*": {
+      "typings/*": ["typings/*"],
+      "*": ["typings/*"]
+    }
+  },
+  "files": [
+    "src",
+    "typings"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/netsmarttech/node-open-protocol"
@@ -34,6 +46,7 @@
     "chai": "^4.2.0",
     "jsdoc": "^3.6.6",
     "mocha": "^8.2.0",
-    "nyc": "^15.1.0"
+    "nyc": "^15.1.0",
+    "typescript": "^4.7.2"
   }
 }

--- a/src/MIDParser.js
+++ b/src/MIDParser.js
@@ -10,7 +10,7 @@ const { Transform } = require('stream');
 const helpers = require("./helpers.js");
 const mids = helpers.getMids();
 
-const constants = require("./constants.json");
+const constants = require("./constants");
 const encodingOP = constants.defaultEncoder;
 
 var debug = util.debuglog('open-protocol');

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,4 +1,4 @@
-{
+module.exports = /** @type {const} */ ({
     "PID": {
         "00001": "Tightening Status",
         "00002": "Station ID",
@@ -435,4 +435,4 @@
         "INCONSISTENCY_MESSAGE_NUMBER": 4
     },
     "defaultEncoder" : "ascii"
-}
+});

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -6,7 +6,7 @@
 
 const fs = require("fs");
 const path = require("path");
-const codes = require('./constants.json');
+const codes = require('./constants');
 const encoding = codes.defaultEncoder;
 
 let midList;

--- a/src/linkLayer.js
+++ b/src/linkLayer.js
@@ -11,7 +11,7 @@ const OpenProtocolParser = require("./openProtocolParser");
 const OpenProtocolSerializer = require("./openProtocolSerializer");
 const MIDParser = require("./MIDParser");
 const MIDSerializer = require("./MIDSerializer");
-const constants = require("./constants.json");
+const constants = require("./constants");
 
 var debug = util.debuglog('open-protocol');
 

--- a/src/mid/0061.js
+++ b/src/mid/0061.js
@@ -129,7 +129,7 @@ const processKey = helpers.processKey;
 const serializerField = helpers.serializerField;
 const serializerKey = helpers.serializerKey;
 
-const constantsMID = require("./MidConstants/MID0061.json");
+const constantsMID = require("./MidConstants/MID0061");
 
 function parser(msg, opts, cb) {
 

--- a/src/mid/MidConstants/MID0061.js
+++ b/src/mid/MidConstants/MID0061.js
@@ -1,4 +1,4 @@
-{
+module.exports = /** @type {const} */ ({
     "strategy": {
         "1": "Torque control",
         "2": "Torque control / angle monitoring",
@@ -183,4 +183,4 @@
         "PVT comp with Snug": 26,
         "No strategy": 99
     }
-}
+});

--- a/src/midCommand.js
+++ b/src/midCommand.js
@@ -1,4 +1,4 @@
-{
+module.exports = /** @type {const} */ ({
     "communicationStop":{
         "request": 3
     },
@@ -132,4 +132,4 @@
     "selectMode": {
         "request": 2606
     }
-}
+});

--- a/src/midData.js
+++ b/src/midData.js
@@ -1,4 +1,4 @@
-{
+module.exports = /** @type {const} */ ({
     "15": "psetSelected",
     "52": "vin",
     "61": "lastTightening",
@@ -21,4 +21,4 @@
     "401": "automaticManualMode",
     "421": "openProtocolCommandsDisabled",
     "501": "motorTuningResultData"
-}
+});

--- a/src/midGroups.js
+++ b/src/midGroups.js
@@ -1,4 +1,4 @@
-{
+module.exports = /** @type {const} */ ({
     "psetSelected": {
         "data": 15,
         "subscribe": 14,
@@ -149,4 +149,4 @@
         "ack": 502,
         "generic": true
     }
-}
+});

--- a/src/midReply.js
+++ b/src/midReply.js
@@ -1,4 +1,4 @@
-{
+module.exports = /** @type {const} */ ({
     "11": "psetID",
     "13": "psetData",
     "2601": "modeIdUpload",
@@ -17,4 +17,4 @@
     "108": "lastPowerMACSTighteningResultBoltData",
     "48": "toolPairingHandling",
     "9999": "keepAlive"
-}
+});

--- a/src/midRequest.js
+++ b/src/midRequest.js
@@ -1,4 +1,4 @@
-{
+module.exports = /** @type {const} */ ({
     "psetID": {
         "request": 10,
         "reply": 11,
@@ -69,4 +69,4 @@
         "reply": 9999,
         "generic": false
     }
-}
+});

--- a/src/openProtocolParser.js
+++ b/src/openProtocolParser.js
@@ -7,7 +7,7 @@
 const util = require('util');
 const { Transform } = require('stream');
 
-const constants = require("./constants.json");
+const constants = require("./constants");
 
 const encodingOP = constants.defaultEncoder;
 

--- a/src/openProtocolSerializer.js
+++ b/src/openProtocolSerializer.js
@@ -7,7 +7,7 @@
 const util = require('util');
 const { Transform } = require('stream');
 
-const constants = require("./constants.json");
+const constants = require("./constants");
 const encodingOP = constants.defaultEncoder;
 
 const helpers = require("./helpers.js");

--- a/src/sessionControlClient.js
+++ b/src/sessionControlClient.js
@@ -9,12 +9,12 @@ const util = require('util');
 const EventEmitter = require('events');
 const LinkLayer = require('../src/linkLayer.js');
 const helpers = require("./helpers.js");
-const midGroupList = require("./midGroups.json");
-const midData = require("./midData.json");
-const constants = require("./constants.json");
-const midRequest = require("./midRequest.json");
-const midCommand = require("./midCommand.json");
-const midReply = require("./midReply.json");
+const midGroupList = require("./midGroups");
+const midData = require("./midData");
+const constants = require("./constants");
+const midRequest = require("./midRequest");
+const midCommand = require("./midCommand");
+const midReply = require("./midReply");
 
 const mids = helpers.getMids();
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,105 @@
+{
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig.json to read more about this file */
+
+    /* Projects */
+    // "incremental": true,                              /* Enable incremental compilation */
+    // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
+    // "tsBuildInfoFile": "./",                          /* Specify the folder for .tsbuildinfo incremental compilation files. */
+    // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects */
+    // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
+    // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
+
+    /* Language and Environment */
+    "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    // "jsx": "preserve",                                /* Specify what JSX code is generated. */
+    // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
+    // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
+    // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h' */
+    // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
+    // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using `jsx: react-jsx*`.` */
+    // "reactNamespace": "",                             /* Specify the object invoked for `createElement`. This only applies when targeting `react` JSX emit. */
+    // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
+    // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
+
+    /* Modules */
+    "module": "commonjs",                                /* Specify what module code is generated. */
+    "rootDir": "./",                                  /* Specify the root folder within your source files. */
+    "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
+    // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
+    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
+    // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
+    // "typeRoots": [],                                  /* Specify multiple folders that act like `./node_modules/@types`. */
+    "types": [
+      "node"
+    ],                                      /* Specify type package names to be included without being referenced in a source file. */
+    // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
+    // "resolveJsonModule": true,                        /* Enable importing .json files */
+    // "noResolve": true,                                /* Disallow `import`s, `require`s or `<reference>`s from expanding the number of files TypeScript should add to a project. */
+
+    /* JavaScript Support */
+    "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the `checkJS` option to get errors from these files. */
+    "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
+    // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from `node_modules`. Only applicable with `allowJs`. */
+
+    /* Emit */
+    "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+    "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
+    "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
+    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+    // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If `declaration` is true, also designates a file that bundles all .d.ts output. */
+    // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
+    // "removeComments": true,                           /* Disable emitting comments. */
+    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
+    // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
+    // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types */
+    // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
+    // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
+    // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
+    // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
+    // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
+    // "newLine": "crlf",                                /* Set the newline character for emitting files. */
+    // "stripInternal": true,                            /* Disable emitting declarations that have `@internal` in their JSDoc comments. */
+    // "noEmitHelpers": true,                            /* Disable generating custom helper functions like `__extends` in compiled output. */
+    // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
+    // "preserveConstEnums": true,                       /* Disable erasing `const enum` declarations in generated code. */
+    "declarationDir": "./typings",                           /* Specify the output directory for generated declaration files. */
+    // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
+
+    /* Interop Constraints */
+    // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
+    // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
+    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables `allowSyntheticDefaultImports` for type compatibility. */
+    // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
+    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
+
+    /* Type Checking */
+    "strict": true,                                      /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied `any` type.. */
+    // "strictNullChecks": true,                         /* When type checking, take into account `null` and `undefined`. */
+    // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
+    // "strictBindCallApply": true,                      /* Check that the arguments for `bind`, `call`, and `apply` methods match the original function. */
+    // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
+    // "noImplicitThis": true,                           /* Enable error reporting when `this` is given the type `any`. */
+    "useUnknownInCatchVariables": false,               /* Type catch clause variables as 'unknown' instead of 'any'. */
+    // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
+    // "noUnusedLocals": true,                           /* Enable error reporting when a local variables aren't read. */
+    // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read */
+    // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
+    // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
+    // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
+    // "noUncheckedIndexedAccess": true,                 /* Include 'undefined' in index signature results */
+    // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
+    // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type */
+    // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
+    // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
+
+    /* Completeness */
+    // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
+    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
+  },
+  "include": [
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -101,5 +101,12 @@
     "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
   },
   "include": [
+    "src/constants.js",
+    "src/midCommand.js",
+    "src/midData.js",
+    "src/midGroups.js",
+    "src/midReply.js",
+    "src/midRequest.js",
+    "src/mid/MidConstants/MID0061.js"
   ]
 }


### PR DESCRIPTION
# What
- convert json consts to js, and add type defs for them

# Why

This is useful for dependent projects that want type safety. For example:

```ts
import midGroups from 'node-open-protocol/typings/src/midGroups';
type MidGroups = typeof midGroups;

// filter out the mid groups that don't have `subscribe`
type Subscribable = {
  [ midGroup in keyof MidGroups ]: MidGroups[midGroup] extends { subscribe: number } ? MidGroups[midGroup] : never;
}

// only valid subscription mid group names would be allowed
const cmd: keyof Subscribable = 'psetSelected';

// only valid subscription mid ids would be allowed
const subscribeMid: Subscribable[keyof Subscribable] = midGroups.psetSelected.subscribe;
```

# Rationale

- there's no way to import a json as a const type (where `subscribe` is stricter than `number`) so thats why the convert to js (see https://github.com/microsoft/TypeScript/issues/32063)